### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ where
 
     while buf.len() < length {
         let bytes = rng.next_u64().to_ne_bytes();
-        for i in bytes.into_iter() {
+        for i in bytes.iter() {
             if alphabet.contains(i) {
                 buf.push(*i);
             };


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.